### PR TITLE
vita: keep textures in user memory for faster reads

### DIFF
--- a/vita/i_video.c
+++ b/vita/i_video.c
@@ -867,6 +867,8 @@ static void SetVideoMode(void)
         // Enable sharp-bilinear-simple shader for sharp pixels without distortion.
         // This has to be done after the SDL renderer is created because that inits vita2d.
         shader = Vita_SetShader(VSH_SHARP_BILINEAR_SIMPLE);
+
+        vita2d_texture_set_alloc_memblock_type(SCE_KERNEL_MEMBLOCK_TYPE_USER_RW);
     }
     else if (!strcmp(scaling_filter, "scale2x"))
     {


### PR DESCRIPTION
Keeping textures in USER_RW memory speeds up reads (and keeps writes at the same speed).

This might speed up Hexen at least a little bit, because it looks to me like there are some texture reads in i_videohr.c when SDL_LockSurface and SDL_UnlockSurface are called in that file.

However, I am not sure if these texture reads are ever actually executed in the Vita version. And I have no fps counter to see if there is any actual speedup.